### PR TITLE
Fix: 에러 핸들링 방식 수정

### DIFF
--- a/controllers/book.controllers.js
+++ b/controllers/book.controllers.js
@@ -7,14 +7,14 @@ import {
 	findSentenceDetails,
 } from '../utils/utils.js';
 
+import { bookErrors, userErrors } from '../utils/errors.js';
+
 export const getBook = async (req, res, next) => {
 	try {
 		const { id } = req.params;
 		const book = await Book.findById(id, '-firestoreId');
 		if (!book) {
-			const error = new Error('등록된 책이 없습니다.');
-			error.status = 404;
-			throw error;
+			return bookErrors.notFound(next);
 		}
 		return res.status(200).json(book);
 	} catch (error) {
@@ -31,9 +31,7 @@ export const getBookSentences = async (req, res, next) => {
 		const book = await Book.findById(id);
 
 		if (!book) {
-			const error = new Error('등록된 책이 없습니다.');
-			error.status = 404;
-			throw error;
+			return bookErrors.notFound(next);
 		}
 
 		const filter = { book: book._id };
@@ -42,9 +40,7 @@ export const getBookSentences = async (req, res, next) => {
 		// 로그인한 사용자가 작성한 문장만 가져오는 경우
 		if (mine) {
 			if (!user) {
-				const error = new Error('로그인 후 이용해주세요.');
-				error.status = 401;
-				throw error;
+				return userErrors.loginRequired(next);
 			}
 			filter.author = user._id;
 		}

--- a/controllers/sentence.controller.js
+++ b/controllers/sentence.controller.js
@@ -2,196 +2,189 @@ import axios from 'axios';
 import Like from '../models/like.model.js';
 import Sentence from '../models/sentence.model.js';
 import {
-  calculateSkip,
-  findSentenceDetails,
-  getUserFromToken,
-  getPaginationResult,
+	calculateSkip,
+	findSentenceDetails,
+	getUserFromToken,
+	getPaginationResult,
 } from '../utils/utils.js';
 import Book from '../models/book.model.js';
+import { sentenceErrors, userErrors } from '../utils/errors.js';
 
 // 문장 전체 목록 가져오기
 export const getSentences = async (req, res, next) => {
-  try {
-    const {
-      page = 1,
-      limit = 20,
-      sortBy = 'createdAt',
-      sortOrder = -1,
-    } = req.query;
-    const skip = calculateSkip(page, limit);
-    const sort = { [sortBy]: Number(sortOrder) };
-    const sentences = await Sentence.find().limit(limit).skip(skip).sort(sort);
-    const user = await getUserFromToken(req);
-    const list = await Promise.all(
-      sentences.map((sentence) => findSentenceDetails(sentence, user?._id))
-    );
+	try {
+		const {
+			page = 1,
+			limit = 20,
+			sortBy = 'createdAt',
+			sortOrder = -1,
+		} = req.query;
+		const skip = calculateSkip(page, limit);
+		const sort = { [sortBy]: Number(sortOrder) };
+		const sentences = await Sentence.find().limit(limit).skip(skip).sort(sort);
+		const user = await getUserFromToken(req);
+		const list = await Promise.all(
+			sentences.map((sentence) => findSentenceDetails(sentence, user?._id))
+		);
 
-    const total = await Sentence.countDocuments();
+		const total = await Sentence.countDocuments();
 
-    return res.status(200).json({
-      ...getPaginationResult({ page, limit, total, list }),
-    });
-  } catch (error) {
-    next(error);
-  }
+		return res.status(200).json({
+			...getPaginationResult({ page, limit, total, list }),
+		});
+	} catch (error) {
+		next(error);
+	}
 };
 
 export const getSentence = async (req, res, next) => {
-  try {
-    const { id } = req.params;
-    const sentence = await Sentence.findById(id);
-    if (!sentence) {
-      const error = new Error('문장을 찾을 수 없습니다.');
-      error.status = 404;
-      throw error;
-    }
-    const result = await findSentenceDetails(sentence);
-    return res.status(200).json({ ...result });
-  } catch (error) {
-    next(error);
-  }
+	try {
+		const { id } = req.params;
+		const sentence = await Sentence.findById(id);
+		if (!sentence) {
+			return sentenceErrors.notFound(next);
+		}
+		const result = await findSentenceDetails(sentence);
+		return res.status(200).json({ ...result });
+	} catch (error) {
+		next(error);
+	}
 };
 
 // kakao api로 책 검색
 export const searchBook = async (req, res, next) => {
-  try {
-    const { query, page = 1, limit = 20, target = 'title' } = req.query;
-    const convertToBookType = (book) => {
-      const { authors, isbn, publisher, title, thumbnail, datetime } = book;
-      return {
-        title,
-        coverUrl: thumbnail,
-        publisher,
-        author: authors,
-        isbn,
-        publishedAt: datetime,
-      };
-    };
-    const { documents: list, meta } = (
-      await axios.get(
-        `https://dapi.kakao.com/v3/search/book?query=${query}&page=${page}&size=${limit}&target=${target}`,
-        {
-          headers: {
-            Authorization: `KakaoAK ${process.env.KAKAO_API_KEY}`,
-          },
-        }
-      )
-    ).data;
-    return res.status(200).json({
-      ...getPaginationResult({
-        page,
-        limit,
-        total: meta.pageable_count,
-        list: list.map(convertToBookType),
-      }),
-    });
-  } catch (error) {
-    next(error);
-  }
+	try {
+		const { query, page = 1, limit = 20, target = 'title' } = req.query;
+		const convertToBookType = (book) => {
+			const { authors, isbn, publisher, title, thumbnail, datetime } = book;
+			return {
+				title,
+				coverUrl: thumbnail,
+				publisher,
+				author: authors,
+				isbn,
+				publishedAt: datetime,
+			};
+		};
+		const { documents: list, meta } = (
+			await axios.get(
+				`https://dapi.kakao.com/v3/search/book?query=${query}&page=${page}&size=${limit}&target=${target}`,
+				{
+					headers: {
+						Authorization: `KakaoAK ${process.env.KAKAO_API_KEY}`,
+					},
+				}
+			)
+		).data;
+		return res.status(200).json({
+			...getPaginationResult({
+				page,
+				limit,
+				total: meta.pageable_count,
+				list: list.map(convertToBookType),
+			}),
+		});
+	} catch (error) {
+		next(error);
+	}
 };
 
 export const createSentence = async (req, res, next) => {
-  try {
-    const { content, book } = req.body;
-    const { user } = req;
-    const { title, coverUrl, publisher, author, isbn, publishedAt } = book;
-    const foundBook = await Book.findOne({ isbn });
-    let bookId = foundBook?._id;
+	try {
+		const { content, book } = req.body;
+		const { user } = req;
+		const { title, coverUrl, publisher, author, isbn, publishedAt } = book;
+		const foundBook = await Book.findOne({ isbn });
+		let bookId = foundBook?._id;
 
-    // 저장된 책이 아니면 새로 만든다.
-    if (!foundBook) {
-      const newBook = await Book.create({
-        title,
-        coverUrl,
-        publisher,
-        author,
-        isbn,
-        publishedAt,
-      });
-      bookId = newBook._id;
-    }
-    const newSentence = await Sentence.create({
-      content,
-      book: bookId,
-      author: user._id,
-    });
+		// 저장된 책이 아니면 새로 만든다.
+		if (!foundBook) {
+			const newBook = await Book.create({
+				title,
+				coverUrl,
+				publisher,
+				author,
+				isbn,
+				publishedAt,
+			});
+			bookId = newBook._id;
+		}
+		const newSentence = await Sentence.create({
+			content,
+			book: bookId,
+			author: user._id,
+		});
 
-    return res.status(200).json({
-      message: '문장을 추가했습니다.',
-      result: newSentence,
-    });
-  } catch (error) {
-    next(error);
-  }
+		return res.status(200).json({
+			message: '문장을 추가했습니다.',
+			result: newSentence,
+		});
+	} catch (error) {
+		next(error);
+	}
 };
 
 export const updateSentence = async (req, res, next) => {
-  try {
-    const { id } = req.params;
-    const { content, book } = req.body;
-    const updatedSentence = await Sentence.findByIdAndUpdate(
-      id,
-      { content, book: book._id },
-      { new: true }
-    );
+	try {
+		const { id } = req.params;
+		const { content, book } = req.body;
+		const updatedSentence = await Sentence.findByIdAndUpdate(
+			id,
+			{ content, book: book._id },
+			{ new: true }
+		);
 
-    return res.status(200).json({
-      message: '문장을 수정했습니다.',
-      result: updatedSentence,
-    });
-  } catch (error) {
-    next(error);
-  }
+		return res.status(200).json({
+			message: '문장을 수정했습니다.',
+			result: updatedSentence,
+		});
+	} catch (error) {
+		next(error);
+	}
 };
 
 export const toggleSentenceLike = async (req, res, next) => {
-  try {
-    const { user } = req;
-    const { id } = req.params;
-    const likeTarget = {
-      user: user._id,
-      target: id,
-      category: 'sentence',
-    };
-    const sentence = await Sentence.findById(id, '-firestoreId');
-    const foundLike = await Like.findOne(likeTarget);
-    if (foundLike) {
-      await Like.findOneAndDelete({ _id: foundLike._id });
-      sentence.likes--;
-    } else {
-      await Like.create(likeTarget);
-      sentence.likes++;
-    }
-    await sentence.save();
-    const sentenceDetail = await findSentenceDetails(sentence, user._id);
-    return res.status(200).json(sentenceDetail);
-  } catch (error) {
-    next(error);
-  }
+	try {
+		const { user } = req;
+		const { id } = req.params;
+		const likeTarget = {
+			user: user._id,
+			target: id,
+			category: 'sentence',
+		};
+		const sentence = await Sentence.findById(id, '-firestoreId');
+		const foundLike = await Like.findOne(likeTarget);
+		if (foundLike) {
+			await Like.findOneAndDelete({ _id: foundLike._id });
+			sentence.likes--;
+		} else {
+			await Like.create(likeTarget);
+			sentence.likes++;
+		}
+		await sentence.save();
+		const sentenceDetail = await findSentenceDetails(sentence, user._id);
+		return res.status(200).json(sentenceDetail);
+	} catch (error) {
+		next(error);
+	}
 };
 
 export const deleteSentence = async (req, res, next) => {
-  try {
-    const { id } = req.params;
-    const { user } = req;
-    const sentence = await Sentence.findById(id);
-    if (!sentence) {
-      const error = new Error();
-      error.message = '해당 문장을 찾을 수 없습니다.';
-      error.status = 404;
-      throw error;
-    }
+	try {
+		const { id } = req.params;
+		const { user } = req;
+		const sentence = await Sentence.findById(id);
+		if (!sentence) {
+			return sentenceErrors.notFound(next);
+		}
 
-    if (sentence.author._id.toString() !== user._id.toString()) {
-      const error = new Error();
-      error.message = '삭제 권한이 없습니다.';
-      error.status = 401;
-      throw error;
-    }
-    await Like.deleteMany({ target: id, category: 'sentence' });
-    await Sentence.findByIdAndDelete(id);
-    return res.status(200).json(true);
-  } catch (error) {
-    next(error);
-  }
+		if (sentence.author._id.toString() !== user._id.toString()) {
+			return userErrors.unauthorized(next);
+		}
+		await Like.deleteMany({ target: id, category: 'sentence' });
+		await Sentence.findByIdAndDelete(id);
+		return res.status(200).json(true);
+	} catch (error) {
+		next(error);
+	}
 };

--- a/controllers/user.controllers.js
+++ b/controllers/user.controllers.js
@@ -3,131 +3,118 @@ import Like from '../models/like.model.js';
 import Sentence from '../models/sentence.model.js';
 import User from '../models/user.model.js';
 import { calculateSkip, findSentenceDetails } from '../utils/utils.js';
+import { userErrors } from '../utils/errors.js';
 
 export const getUser = (req, res, next) => {
-  const { user } = req;
-  try {
-    if (user) {
-      const { uid, ...userInfo } = user._doc;
-      return res.status(200).json({
-        ...userInfo,
-      });
-    } else {
-      const err = new Error();
-      err.message = 'Not authorized';
-      err.statusCode = 401;
-      throw err;
-    }
-  } catch (error) {
-    next(error);
-  }
+	const { user } = req;
+	if (user) {
+		const { uid, ...userInfo } = user._doc;
+		return res.status(200).json({
+			...userInfo,
+		});
+	} else {
+		return userErrors.unauthorized(next);
+	}
 };
 
 export const updateUser = async (req, res, next) => {
-  try {
-    const { user } = req;
-    const { name, profileUrl } = req.body;
-    const filter = { _id: user._id };
-    const update = { name, profileUrl };
-    if (user) {
-      const updatedUser = await User.findOneAndUpdate(filter, update, {
-        new: true,
-      });
-      return res.status(200).json({ ...updatedUser._doc });
-    } else {
-      const err = new Error();
-      err.message = 'Not authorized';
-      err.statusCode = 401;
-      throw err;
-    }
-  } catch (error) {
-    next(error);
-  }
+	const { user } = req;
+	const { name, profileUrl } = req.body;
+	const filter = { _id: user._id };
+	const update = { name, profileUrl };
+	if (user) {
+		const updatedUser = await User.findOneAndUpdate(filter, update, {
+			new: true,
+		});
+		return res.status(200).json({ ...updatedUser._doc });
+	} else {
+		return userErrors.unauthorized(next);
+	}
 };
 
 // 회원 탈퇴
 export const deleteUser = async (req, res, next) => {
-  try {
-    const { user } = req;
-    // 좋아요 삭제
-    await Like.deleteMany({ user: user._id });
-    // 작성한 문장 삭제
-    await Sentence.deleteMany({ author: user._id });
-    // 사용자 정보 삭제
-    await User.findByIdAndDelete(user._id);
-    // 토큰 취소
-    await admin.auth().revokeRefreshTokens(user.uid);
-    // firebase auth에서 삭제
-    await admin.auth().deleteUser(user.uid);
+	const { user } = req;
+	if (user) {
+		// 좋아요 삭제
+		await Like.deleteMany({ user: user._id });
+		// 작성한 문장 삭제
+		await Sentence.deleteMany({ author: user._id });
+		// 사용자 정보 삭제
+		await User.findByIdAndDelete(user._id);
+		// 토큰 취소
+		await admin.auth().revokeRefreshTokens(user.uid);
+		// firebase auth에서 삭제
+		await admin.auth().deleteUser(user.uid);
 
-    return res.status(200).json('회원 탈퇴하였습니다.');
-  } catch (error) {
-    next(error);
-  }
+		return res.status(200).json('회원 탈퇴하였습니다.');
+	} else {
+		return userErrors.unauthorized(next);
+	}
 };
 
 // 사용자가 작성한 문장 목록
 export const getUserSentence = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const {
-      page = 1,
-      limit = 20,
-      sortBy = 'createdAt',
-      sortOrder = -1,
-    } = req.query;
-    const sort = { [sortBy]: Number(sortOrder) };
-    const skip = calculateSkip(page, limit);
+	try {
+		const { userId } = req.params;
+		const {
+			page = 1,
+			limit = 20,
+			sortBy = 'createdAt',
+			sortOrder = -1,
+		} = req.query;
+		const sort = { [sortBy]: Number(sortOrder) };
+		const skip = calculateSkip(page, limit);
 
-    const sentences = await Sentence.find({ author: userId }, '-firestoreId')
-      .limit(limit)
-      .skip(skip)
-      .sort(sort);
+		const sentences = await Sentence.find({ author: userId }, '-firestoreId')
+			.limit(limit)
+			.skip(skip)
+			.sort(sort);
 
-    const list = await Promise.all(
-      sentences.map((sentence) => findSentenceDetails(sentence, userId))
-    );
+		const list = await Promise.all(
+			sentences.map((sentence) => findSentenceDetails(sentence, userId))
+		);
 
-    const total = await Sentence.countDocuments({ author: userId });
+		const total = await Sentence.countDocuments({ author: userId });
 
-    return res.status(200).json({
-      list,
-      page: Number(page),
-      limit: Number(limit),
-      total: Number(total),
-      pageTotal: Math.ceil(total / limit),
-    });
-  } catch (error) {
-    next(error);
-  }
+		return res.status(200).json({
+			list,
+			page: Number(page),
+			limit: Number(limit),
+			total: Number(total),
+			pageTotal: Math.ceil(total / limit),
+		});
+	} catch (error) {
+		next(error);
+	}
 };
 
 // 사용자가 좋아요를 누른 목록
 export const getUserLike = async (req, res, next) => {
-  try {
-    const { userId } = req.params;
-    const {
-      page = 1,
-      limit = 20,
-      category = 'sentence',
-      sortBy = 'createdAt',
-      sortOrder = -1,
-    } = req.query;
-    const skip = calculateSkip(page, limit);
-    const sort = { [sortBy]: Number(sortOrder) };
-    const filter = { category, user: userId };
-    const likes = await Like.find(filter).limit(limit).skip(skip).sort(sort);
-    const total = await Like.countDocuments(filter);
-    const sentences = await Promise.all(
-      likes.map((like) => Sentence.findById(like.target, '-firestoreId'))
-    );
-    const list = await Promise.all(
-      sentences.map((sentence) => findSentenceDetails(sentence, userId))
-    );
-    return res
-      .status(200)
-      .json({ total, page, limit, list, pageTotal: Math.ceil(total / limit) });
-  } catch (error) {
-    next(error);
-  }
+	try {
+		const { userId } = req.params;
+		const {
+			page = 1,
+			limit = 20,
+			category = 'sentence',
+			sortBy = 'createdAt',
+			sortOrder = -1,
+		} = req.query;
+		const skip = calculateSkip(page, limit);
+		const sort = { [sortBy]: Number(sortOrder) };
+		const filter = { category, user: userId };
+		const likes = await Like.find(filter).limit(limit).skip(skip).sort(sort);
+		const total = await Like.countDocuments(filter);
+		const sentences = await Promise.all(
+			likes.map((like) => Sentence.findById(like.target, '-firestoreId'))
+		);
+		const list = await Promise.all(
+			sentences.map((sentence) => findSentenceDetails(sentence, userId))
+		);
+		return res
+			.status(200)
+			.json({ total, page, limit, list, pageTotal: Math.ceil(total / limit) });
+	} catch (error) {
+		next(error);
+	}
 };

--- a/middleware/auth.middleware.js
+++ b/middleware/auth.middleware.js
@@ -1,11 +1,7 @@
 import { getUserFromToken } from '../utils/utils.js';
+import { userErrors } from '../utils/errors.js';
 
 export const authGuard = async (req, res, next) => {
-	const throwError = () => {
-		const err = new Error('Not authorized');
-		err.statusCode = 401;
-		next(err);
-	};
 	if (
 		req.headers.authorization &&
 		req.headers.authorization.startsWith('Bearer')
@@ -13,14 +9,14 @@ export const authGuard = async (req, res, next) => {
 		try {
 			const user = await getUserFromToken(req);
 			if (!user) {
-				throwError();
+				return userErrors.unauthorized(next);
 			}
 			req.user = user;
 			next();
 		} catch (error) {
-			throwError();
+			return userErrors.unauthorized(next);
 		}
 	} else {
-		throwError();
+		return userErrors.unauthorized(next);
 	}
 };

--- a/middleware/error.middleware.js
+++ b/middleware/error.middleware.js
@@ -2,8 +2,7 @@ export const errorResponseHandler = (error, req, res, next) => {
 	if (process.env.NODE_ENV !== 'production') {
 		console.log(error);
 	}
-
-	const statusCode = error.statusCode || 500;
+	const statusCode = error.status || 500;
 	res.status(statusCode).json({
 		message: error.message,
 		stack: process.env.NODE_ENV === 'production' ? null : error.stack,

--- a/routes/sentence.route.js
+++ b/routes/sentence.route.js
@@ -1,23 +1,23 @@
 import express from 'express';
 import { authGuard } from '../middleware/auth.middleware.js';
 import {
-  deleteSentence,
-  getSentences,
-  getSentence,
-  createSentence,
-  toggleSentenceLike,
-  updateSentence,
-  searchBook,
+	deleteSentence,
+	getSentences,
+	getSentence,
+	createSentence,
+	toggleSentenceLike,
+	updateSentence,
+	searchBook,
 } from '../controllers/sentence.controller.js';
-import { valiateSentence } from '../utils/validators.js';
+import { validateSentence } from '../utils/validators.js';
 
 const router = express.Router();
 
 router.get('/', getSentences);
 router.get('/:id', getSentence);
 router.get('/search/book', searchBook);
-router.post('/', authGuard, valiateSentence, createSentence);
-router.put('/:id', authGuard, valiateSentence, updateSentence);
+router.post('/', authGuard, validateSentence, createSentence);
+router.put('/:id', authGuard, validateSentence, updateSentence);
 router.delete('/:id', authGuard, deleteSentence);
 router.put('/:id/like', authGuard, toggleSentenceLike);
 

--- a/utils/errors.js
+++ b/utils/errors.js
@@ -1,0 +1,28 @@
+const createError = (message, status) => {
+	const error = new Error(message);
+	error.status = status;
+	return error;
+};
+
+const userErrors = {
+	loginRequired(next) {
+		next(createError('로그인 후 이용해주세요.', 401));
+	},
+	unauthorized(next) {
+		next(createError('권한이 없습니다.', 401));
+	},
+};
+
+const bookErrors = {
+	notFound(next) {
+		next(createError('등록된 책이 없습니다.', 404));
+	},
+};
+
+const sentenceErrors = {
+	notFound(next) {
+		next(createError('문장을 찾을 수 없습니다.', 404));
+	},
+};
+
+export { bookErrors, userErrors, sentenceErrors };

--- a/utils/validators.js
+++ b/utils/validators.js
@@ -1,34 +1,34 @@
 import { body, validationResult } from 'express-validator';
 
-// validatoion 결과 확인
+// validation 결과 확인
 export const validationErrorHandler = (req, res, next) => {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    const error = new Error('잘못된 요청입니다.');
-    error.status = 400;
-    error.errors = errors.array();
-    throw error;
-  }
-  next();
+	const errors = validationResult(req);
+	if (!errors.isEmpty()) {
+		const error = new Error('잘못된 요청입니다.');
+		error.status = 400;
+		error.errors = errors.array();
+		next(error);
+	}
+	next();
 };
 
-export const valiateSentence = [
-  body('content').trim().isLength({ min: 5 }),
-  body('book').custom(async (value) => {
-    if (!value) {
-      const error = new Error('책 정보를 입력해주세요.');
-      error.status = 400;
-      throw error;
-    }
-    // 새로운 책을 등록하는 경우에는 필수값을 확인한다.
-    const { title, publisher, author, isbn } = value;
-    if (!title || !publisher || !author || !isbn) {
-      const error = new Error('책 정보가 잘못되었습니다.');
-      error.status = 400;
-      throw error;
-    } else {
-      return true;
-    }
-  }),
-  validationErrorHandler,
+export const validateSentence = [
+	body('content').trim().isLength({ min: 5 }),
+	body('book').custom(async (value) => {
+		if (!value) {
+			const error = new Error('책 정보를 입력해주세요.');
+			error.status = 400;
+			next(error);
+		}
+		// 새로운 책을 등록하는 경우에는 필수값을 확인한다.
+		const { title, publisher, author, isbn } = value;
+		if (!title || !publisher || !author || !isbn) {
+			const error = new Error('책 정보가 잘못되었습니다.');
+			error.status = 400;
+			next(error);
+		} else {
+			return true;
+		}
+	}),
+	validationErrorHandler,
 ];


### PR DESCRIPTION
[ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client 에러
- 미들웨어에서 에러를 보낸 뒤 컨트롤러에서 에러를 던져서 발생하는 문제, 하나의 요청에는 하나의 응답만 보내야 한다.
- next를 호출해서 에러 핸들링하는 미들웨어에서 에러 응답을 하도록 한다.

에러 관리 유틸 추가
- 중복되는 에러들을 한 곳에서 관리하도록 유틸을 추가